### PR TITLE
gh-117: section for inverse distances

### DIFF
--- a/docs/api/protocols.rst
+++ b/docs/api/protocols.rst
@@ -26,12 +26,17 @@ Distance
 
 .. autoclass:: HasAngularDiameterDistance
 .. autoclass:: HasComovingDistance
-.. autoclass:: HasInverseComovingDistance
 .. autoclass:: HasHubbleDistance
 .. autoclass:: HasLookbackDistance
 .. autoclass:: HasLuminosityDistance
 .. autoclass:: HasProperDistance
 .. autoclass:: HasTransverseComovingDistance
+
+
+Inverse distance
+----------------
+
+.. autoclass:: HasInverseComovingDistance
 
 
 Volume

--- a/docs/api/reference.rst
+++ b/docs/api/reference.rst
@@ -33,12 +33,23 @@ Distance
 
    ~HasAngularDiameterDistance.angular_diameter_distance
    ~HasComovingDistance.comoving_distance
-   ~HasInverseComovingDistance.inv_comoving_distance
    ~HasHubbleDistance.hubble_distance
    ~HasLookbackDistance.lookback_distance
    ~HasLuminosityDistance.luminosity_distance
    ~HasProperDistance.proper_distance
    ~HasTransverseComovingDistance.transverse_comoving_distance
+
+
+Inverse distance
+----------------
+
+These functions return a redshift given a distance.
+
+.. autosummary::
+   :toctree: reference
+   :template: reference
+
+   ~HasInverseComovingDistance.inv_comoving_distance
 
 
 Volume


### PR DESCRIPTION
## Description

This pull request adds a section "Inverse distances" to the docs. This acknowledges the fact that inverse distance functions have a different signature `distance -> redshift` than distance functions.

Closes #117

## PR Checklist

- [x] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [x] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [x] Ensure linear history by rebasing, when requested by the maintainer.
