### PR TITLE
gh-116: switch to hatch and dynamic versions for v0.2.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,15 @@ list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
+
+def parse_package_authors(author_email):
+    """Get names from a package's Author-email field."""
+    import email, email.policy
+
+    msg = email.message_from_string(f"To: {author_email}", policy=email.policy.default)
+    return ", ".join(address.display_name for address in msg["to"].addresses)
+
+
 # -- Project information -----------------------------------------------------
 
 import importlib.metadata
@@ -14,7 +23,7 @@ import importlib.metadata
 metadata = importlib.metadata.metadata("cosmology.api")
 
 project = metadata["Name"]
-author = metadata["Author-email"]
+author = parse_package_authors(metadata["Author-email"])
 copyright = f"2025, {author}"
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,37 +7,19 @@ list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
-import os
-import sys
-import tomli
-
-sys.path.append(os.path.abspath("../src"))
-
-
 # -- Project information -----------------------------------------------------
 
+import importlib.metadata
 
-def read_pyproject():
-    """Get author information from package metadata."""
-    with open(os.path.abspath("../pyproject.toml"), "rb") as f:
-        toml = tomli.load(f)
+metadata = importlib.metadata.metadata("cosmology.api")
 
-    project = dict(toml["project"])
-    version = project["version"]
-    authors = ", ".join(d["name"] for d in project["authors"])
-
-    return version, authors
-
-
-package_version, package_authors = read_pyproject()
-
-project = "cosmology.api"
-author = package_authors
-copyright = f"2023, {author}"
+project = metadata["Name"]
+author = metadata["Author-email"]
+copyright = f"2025, {author}"
 
 
 # The full version, including alpha/beta/rc tags.
-release = package_version
+release = metadata["Version"]
 # The short X.Y version.
 version = release.partition("-")[0]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,10 @@
+[build-system]
+  requires = ["hatchling", "hatch-vcs"]
+  build-backend = "hatchling.build"
+
+
 [project]
   name = "cosmology.api"
-  version = "0.1.1.dev"
   description = "Cosmology API standard"
   readme = "README.rst"
   requires-python = ">=3.9"
@@ -23,6 +27,7 @@
   ]
   dependencies = [
   ]
+  dynamic = ["version"]
 
 [project.optional-dependencies]
   all = [
@@ -52,23 +57,6 @@
   documentation = "https://cosmology.readthedocs.org/projects/api"
 
 
-[build-system]
-  requires = [
-    "mypy>=0.991",
-    "setuptools>=45.0",
-    "setuptools_scm[toml]>=6.3.1",
-    "wheel",
-  ]
-
-  build-backend = 'setuptools.build_meta'
-
-
-[tool.setuptools]
-  package-dir = {"" = "src"}
-
-[tool.setuptools_scm]
-
-
 [tool.coverage.run]
   omit = ["tests/*"]
 
@@ -92,6 +80,15 @@
     "def _ipython_key_completions_",
   ]
 
+[tool.hatch]
+build.targets.sdist.exclude = [
+  ".*",
+  "conftest.py",
+  "docs/*",
+  "tests/*",
+]
+build.targets.wheel.packages = ["src/cosmology"]
+version.source = "vcs"
 
 [tool.mypy]
   python_version = 3.9


### PR DESCRIPTION
## Description
This pull request switches to the hatchling build backend with dynamic versioning. This means no manual step when releasing a new package.

## PR Checklist

- [x] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
