### PR TITLE
fix dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ build.targets.wheel.packages = ["src/cosmology"]
 version.source = "vcs"
 
 [tool.mypy]
-  python_version = 3.9
+  python_version = 3.10
 
   namespace_packages = true
   explicit_package_bases = true
@@ -142,7 +142,7 @@ filterwarnings = [
 
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 88
 
 [tool.ruff.lint]

--- a/src/cosmology/api/_array_api/array.py
+++ b/src/cosmology/api/_array_api/array.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
-from typing_extensions import Self
-
 if TYPE_CHECKING:
     # STDLIB
-    from types import EllipsisType  # type: ignore[attr-defined]
+    from types import EllipsisType
+    from typing import Self
 
     # LOCAL
     from .dtype import DTypeConformant


### PR DESCRIPTION
PR #120 accidentally introduced a dependency on typing-extensions that isn't declared in v0.3.

Instead of doing that, I added `Self` to the type-checking block and bumped the Python version for mypy and ruff to 3.10 so they don't complain about it. If you want to type-check on py39, you're on your own.