### PR TITLE
Write coverage data to repo root for Codecov upload

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,11 @@ indexserver =
 # Suppress display of matplotlib plots generated during docs build
 setenv =
     clocale: LC_ALL = C
+    # Tests run in a temporary directory (see changedir below), so point the
+    # coverage data file back at the repo root. The OpenAstronomy tox workflow
+    # requires the .coverage file to be in the root to combine and upload it.
+    # https://github-actions-workflows.openastronomy.org/en/stable/tox.html#coverage
+    cov: COVERAGE_FILE = {toxinidir}/.coverage
 
 # Pass through the following environment variables which may be needed for the CI
 passenv = HOME, WINDIR, LC_ALL, LC_CTYPE, CC, CI, IS_CRON, ARCH_ON_CI


### PR DESCRIPTION
## Problem

CI is failing on `-cov` test jobs at the Codecov upload step (e.g. [run 29299462239](https://github.com/cosmology-api/cosmology.api/actions/runs/29299462239/job/86980029645)). The tests themselves pass, but the job errors with:

> No `.coverage` file was found in the root directory, this is now a requirement for uploading coverage to Codecov.
> No coverage reports found. Please make sure you're generating reports successfully.

## Root cause

`tox.ini` runs tests in a temporary directory (`changedir = .tmp/{envname}`) so the package isn't imported from the source tree. Consequently `pytest-cov` writes the `.coverage` data file **inside that temp directory**, not the repository root. The OpenAstronomy tox workflow now requires the `.coverage` file to live in the workspace root so it can combine reports and upload them to Codecov, so it finds zero coverage files and fails.

I reproduced the mechanism locally: with `pytest --cov` run from a subdirectory the `.coverage` file lands in that subdirectory; setting `COVERAGE_FILE` to the root redirects it back to the root.

## Fix

Set `COVERAGE_FILE = {toxinidir}/.coverage` for coverage environments (gated on the `cov:` factor), as documented at <https://github-actions-workflows.openastronomy.org/en/stable/tox.html#coverage>. This lands the coverage data file in the repo root where the workflow expects it.

Verified with `tox config -e py312-test-cov` that `COVERAGE_FILE` resolves to the repo root, and confirmed it is not set for non-coverage environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)